### PR TITLE
feat(ai): switch AI integration from Gemini to Anthropic Claude

### DIFF
--- a/.github/workflows/devsecops.yml
+++ b/.github/workflows/devsecops.yml
@@ -181,10 +181,10 @@ jobs:
           retention-days: 1
 
   # ─────────────────────────────────────────────────────────────────────────────
-  # JOB 5: AI Analysis — Gemini API
+  # JOB 5: AI Analysis — Anthropic Claude API
   # ─────────────────────────────────────────────────────────────────────────────
   ai-vulnerability-analysis:
-    name: AI Vulnerability Analysis (Gemini)
+    name: AI Vulnerability Analysis (Claude)
     runs-on: ubuntu-latest
     needs: [snyk-dependency-scan, owasp-dependency-check]
 
@@ -209,10 +209,10 @@ jobs:
           name: owasp-report
           path: reports/owasp/
 
-      - name: Run Gemini AI analysis
+      - name: Run Claude AI analysis
         working-directory: ai
         env:
-          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
           node analyze.js \
             ../reports/snyk-dep-report.json \

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ## Overview
 
-This project designs and evaluates an AI-enhanced DevSecOps pipeline using a sample Node.js web application. It compares two security scanning tools (Snyk and OWASP Dependency-Check), integrates Google Gemini AI for vulnerability analysis and remediation suggestions, and provides real-time monitoring via Prometheus and Grafana.
+This project designs and evaluates an AI-enhanced DevSecOps pipeline using a sample Node.js web application. It compares two security scanning tools (Snyk and OWASP Dependency-Check), integrates Anthropic Claude AI for vulnerability analysis and remediation suggestions, and provides real-time monitoring via Prometheus and Grafana.
 
 ---
 
@@ -29,7 +29,7 @@ Developer Push
 │                     └────────┬────────┘             │
 │                              ▼                      │
 │                    ┌──────────────────┐             │
-│                    │  Gemini AI       │             │
+│                    │  Claude AI       │             │
 │                    │  Analysis        │             │
 │                    └────────┬─────────┘             │
 │                             ▼                       │
@@ -117,7 +117,7 @@ ssw559-project/
 │       └── dashboards/
 │           └── devsecops-dashboard.json   # Grafana dashboard
 ├── ai/
-│   ├── analyze.js                 # Gemini API vulnerability analyzer
+│   ├── analyze.js                 # Anthropic Claude API vulnerability analyzer
 │   └── package.json
 ├── scripts/
 │   └── generate-comparison.js     # Snyk vs OWASP comparison report
@@ -139,7 +139,7 @@ ssw559-project/
 | `snyk-dependency-scan` | Snyk npm dependency scan | build-and-test |
 | `owasp-dependency-check` | OWASP NVD-based scan | build-and-test |
 | `docker-build-and-scan` | Build image + Snyk container scan | build-and-test |
-| `ai-vulnerability-analysis` | Gemini AI analysis of scan results | snyk + owasp |
+| `ai-vulnerability-analysis` | Claude AI analysis of scan results | snyk + owasp |
 | `generate-comparison-report` | Snyk vs OWASP comparison doc | snyk + owasp + AI |
 | `deploy` | Validate + smoke-test full stack | AI + docker |
 
@@ -168,7 +168,7 @@ Go to your repository → **Settings** → **Secrets and variables** → **Actio
 | Secret Name | Description | Where to Get It |
 |-------------|-------------|-----------------|
 | `SNYK_TOKEN` | Snyk API authentication token | [app.snyk.io](https://app.snyk.io) → Account Settings → API Token |
-| `GEMINI_API_KEY` | Google Gemini API key | [aistudio.google.com](https://aistudio.google.com) → Get API Key |
+| `ANTHROPIC_API_KEY` | Anthropic Claude API key | [console.anthropic.com](https://console.anthropic.com) → API Keys |
 | `NVD_API_KEY` | (Optional) NVD API key for faster OWASP scans | [nvd.nist.gov/developers/request-an-api-key](https://nvd.nist.gov/developers/request-an-api-key) |
 
 ---
@@ -219,7 +219,7 @@ The pre-provisioned dashboard includes:
 
 ## AI Integration
 
-The pipeline uses **Google Gemini 1.5 Flash** to:
+The pipeline uses **Anthropic Claude Haiku (claude-haiku-4-5-20251001)** to:
 
 1. Parse JSON reports from both Snyk and OWASP
 2. Identify critical and high-severity vulnerabilities

--- a/ai/analyze.js
+++ b/ai/analyze.js
@@ -1,10 +1,10 @@
 /**
- * AI Vulnerability Analyzer!
- * Uses Google Gemini API to analyze vulnerability scan results from Snyk and OWASP
+ * AI Vulnerability Analyzer
+ * Uses Anthropic Claude API to analyze vulnerability scan results from Snyk and OWASP
  * and generate a human-readable remediation report.
  *
  * Usage:
- *   GEMINI_API_KEY=<key> node analyze.js <snyk-report.json> <owasp-report.json>
+ *   ANTHROPIC_API_KEY=<key> node analyze.js <snyk-report.json> <owasp-report.json>
  */
 
 'use strict';
@@ -14,9 +14,9 @@ const fs    = require('fs');
 const path  = require('path');
 
 // ─── Config ───────────────────────────────────────────────────────────────────
-const GEMINI_API_KEY = process.env.GEMINI_API_KEY || '';
-const GEMINI_MODEL   = 'gemini-2.0-flash';
-const GEMINI_URL     = `https://generativelanguage.googleapis.com/v1beta/models/${GEMINI_MODEL}:generateContent?key=${GEMINI_API_KEY}`;
+const ANTHROPIC_API_KEY = process.env.ANTHROPIC_API_KEY || '';
+const ANTHROPIC_MODEL   = 'claude-haiku-4-5-20251001';
+const ANTHROPIC_URL     = 'https://api.anthropic.com/v1/messages';
 const OUTPUT_FILE    = path.join(__dirname, 'ai-report.md');
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -67,26 +67,25 @@ function extractOwaspVulns(report) {
   return { count: vulns.length, vulns };
 }
 
-function callGeminiApi(prompt) {
+function callAnthropicApi(prompt) {
   return new Promise((resolve, reject) => {
     const body = JSON.stringify({
-      contents: [{ parts: [{ text: prompt }] }],
-      generationConfig: {
-        temperature:     0.2,
-        maxOutputTokens: 4096,
-        topK:            40,
-        topP:            0.95,
-      },
+      model:       ANTHROPIC_MODEL,
+      max_tokens:  4096,
+      temperature: 0.2,
+      messages: [{ role: 'user', content: prompt }],
     });
 
-    const url = new URL(GEMINI_URL);
+    const url = new URL(ANTHROPIC_URL);
     const options = {
       hostname: url.hostname,
-      path:     url.pathname + url.search,
+      path:     url.pathname,
       method:   'POST',
       headers:  {
-        'Content-Type':   'application/json',
-        'Content-Length': Buffer.byteLength(body),
+        'x-api-key':         ANTHROPIC_API_KEY,
+        'anthropic-version': '2023-06-01',
+        'content-type':      'application/json',
+        'content-length':    Buffer.byteLength(body),
       },
     };
 
@@ -96,15 +95,15 @@ function callGeminiApi(prompt) {
       res.on('end', () => {
         try {
           const parsed = JSON.parse(data);
-          if (parsed.error) {
-            reject(new Error(`Gemini API error: ${parsed.error.message}`));
+          if (parsed.type === 'error') {
+            reject(new Error(`Anthropic API error: ${parsed.error.message}`));
             return;
           }
-          const text = parsed.candidates?.[0]?.content?.parts?.[0]?.text;
-          if (!text) reject(new Error('No text content in Gemini response'));
+          const text = parsed.content?.[0]?.text;
+          if (!text) reject(new Error('No text content in Anthropic response'));
           else resolve(text);
         } catch (e) {
-          reject(new Error(`Failed to parse Gemini response: ${e.message}`));
+          reject(new Error(`Failed to parse Anthropic response: ${e.message}`));
         }
       });
     });
@@ -112,7 +111,7 @@ function callGeminiApi(prompt) {
     req.on('error', reject);
     req.setTimeout(60000, () => {
       req.destroy();
-      reject(new Error('Gemini API request timed out'));
+      reject(new Error('Anthropic API request timed out'));
     });
     req.write(body);
     req.end();
@@ -230,7 +229,7 @@ The application contains known exploitable vulnerabilities (Prototype Pollution 
 5. **[Medium-term]** Add pre-commit hook to run \`npm audit\` locally before push
 
 ## 7. AI Analysis Confidence
-**Confidence: Medium** — This is a fallback report generated without the Gemini API (API key not configured). Set the \`GEMINI_API_KEY\` secret in your GitHub repository for full AI-powered analysis.
+**Confidence: Medium** — This is a fallback report generated without the Anthropic API (API key not configured). Set the \`ANTHROPIC_API_KEY\` secret in your GitHub repository for full AI-powered analysis.
 `;
 }
 
@@ -256,19 +255,19 @@ async function main() {
 
   let analysisBody;
 
-  if (GEMINI_API_KEY) {
-    console.log('📡  Calling Gemini API...');
+  if (ANTHROPIC_API_KEY) {
+    console.log('📡  Calling Anthropic Claude API...');
     try {
       const prompt = buildPrompt(snyk, owasp);
-      analysisBody = await callGeminiApi(prompt);
-      console.log('✅  Gemini analysis complete');
+      analysisBody = await callAnthropicApi(prompt);
+      console.log('✅  Claude analysis complete');
     } catch (err) {
-      console.error(`❌  Gemini API failed: ${err.message}`);
+      console.error(`❌  Anthropic API failed: ${err.message}`);
       console.log('⚙️  Falling back to rule-based report...');
       analysisBody = fallbackReport(snyk, owasp);
     }
   } else {
-    console.warn('⚠️  GEMINI_API_KEY not set — generating rule-based fallback report');
+    console.warn('⚠️  ANTHROPIC_API_KEY not set — generating rule-based fallback report');
     analysisBody = fallbackReport(snyk, owasp);
   }
 
@@ -276,7 +275,7 @@ async function main() {
   const fullReport = `# 🔐 AI-Generated Vulnerability Analysis Report
 
 > **Generated:** ${timestamp}  
-> **AI Model:** Google Gemini 1.5 Flash  
+> **AI Model:** Anthropic Claude Haiku (claude-haiku-4-5-20251001)
 > **Pipeline:** GitHub Actions — DevSecOps CI/CD  
 > **Project:** SSW 559 — AI-Enhanced DevSecOps Pipeline  
 > **Team:** Jaden Fernandes · Ryan Raymundo · Azeel Sajjad · Edzel Roque · Lucas Ha  

--- a/ai/package.json
+++ b/ai/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-vulnerability-analyzer",
   "version": "1.0.0",
-  "description": "Gemini AI-powered vulnerability analysis for DevSecOps pipeline",
+  "description": "Anthropic Claude AI-powered vulnerability analysis for DevSecOps pipeline",
   "main": "analyze.js",
   "scripts": {
     "analyze": "node analyze.js"

--- a/scripts/generate-comparison.cjs
+++ b/scripts/generate-comparison.cjs
@@ -155,7 +155,7 @@ For **compliance and audit trails**, **OWASP Dependency-Check** is preferred due
 
 ## AI Analysis Summary
 
-${aiReport ? '> *Full AI analysis is appended below. See the ai-vulnerability-report artifact for the complete Gemini-generated report.*' : '> *AI report not available — configure GEMINI_API_KEY secret to enable.*'}
+${aiReport ? '> *Full AI analysis is appended below. See the ai-vulnerability-report artifact for the complete Claude-generated report.*' : '> *AI report not available — configure ANTHROPIC_API_KEY secret to enable.*'}
 
 ---
 


### PR DESCRIPTION
## Summary
- Replace Google Gemini API with Anthropic Claude Haiku (`claude-haiku-4-5-20251001`) in `ai/analyze.js`
- Rename `GEMINI_API_KEY` → `ANTHROPIC_API_KEY` in workflow, docs, and all user-facing strings
- Update GitHub Actions job/step names and README to reflect the new provider

## Test plan
- [ ] Add `ANTHROPIC_API_KEY` secret to GitHub repo (Settings → Secrets → Actions)
- [ ] Trigger a pipeline run and confirm job is named "AI Vulnerability Analysis (Claude)"
- [ ] Verify step log shows `✅  Claude analysis complete`
- [ ] Download `ai-vulnerability-report` artifact and confirm header reads `AI Model: Anthropic Claude Haiku`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)